### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,20 @@
+name: Ruby
+
+on: [push, pull_request]
+
+jobs:
+  validate_openapi:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        bundler-cache: true
+        ruby-version: ruby
+    - name: Install dependencies
+      run: bundle install
+    - name: Check openapi.yml
+      run: bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,11 @@
+source "https://rubygems.org"
+
+gem "openapi3_parser"
+gem "rake"
+
+# TODO: The `openapi3_parser` and `yaml_normalizer` gems have a compatibility issue
+#       as both have pinned the `psych` dependency to different versions. We are
+#       currently using a forked version of the `yaml_normalizer` gem which has the
+#       `pysch` gem unpinned. Once the gems are compatible we can remove this git source.
+#       PR: https://github.com/Sage/yaml_normalizer/pull/53
+gem "yaml_normalizer", git: "https://github.com/mxenabled/yaml_normalizer"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,36 @@
+GIT
+  remote: https://github.com/mxenabled/yaml_normalizer
+  revision: 0bf191ea947ee32b1f980a638e3710b32797b070
+  specs:
+    yaml_normalizer (1.2.1)
+      peach (~> 0.5)
+      psych (>= 2.2)
+      rake (~> 12.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    commonmarker (0.21.2)
+      ruby-enum (~> 0.5)
+    concurrent-ruby (1.1.8)
+    i18n (1.8.9)
+      concurrent-ruby (~> 1.0)
+    openapi3_parser (0.9.0)
+      commonmarker (~> 0.17)
+      psych (~> 3.1)
+    peach (0.5.1)
+    psych (3.3.1)
+    rake (12.3.3)
+    ruby-enum (0.9.0)
+      i18n
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  openapi3_parser
+  rake
+  yaml_normalizer!
+
+BUNDLED WITH
+   2.2.11

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,40 @@
+require "openapi3_parser"
+require "yaml_normalizer"
+
+task :default => [:validate_openapi, :normalize_yaml]
+
+task :normalize do
+  ::YamlNormalizer::Services::Normalize.call("openapi.yml")
+end
+
+task :normalize_yaml do
+  check_passed = ::YamlNormalizer::Services::Check.call("openapi.yml")
+
+  unless check_passed
+    puts "Please normalize openapi.yml with 'bundle exec rake normalize'"
+    exit 1
+  end
+end
+
+task :validate_openapi do
+  openapi = ::Openapi3Parser.load_file("openapi.yml")
+
+  unless openapi.valid?
+    errors_count = openapi.errors.count
+
+    puts "#{errors_count} validation error(s) found."
+    openapi.errors.each_with_index do |error, index|
+      context = error.context.source_location.pointer.fragment
+      error_message = error.message
+      unescaped_context = ::CGI.unescape(context)
+
+      puts ""
+      puts "#{index + 1})"
+      puts "   Message: #{error_message}"
+      puts "   Context: #{unescaped_context}"
+    end
+    exit 1
+  end
+
+  puts "[PASSED] valid OpenAPI"
+end


### PR DESCRIPTION
Adds CI via GitHub Actions. First, it checks if the openapi.yml file is
valid OpenAPI with the `openapi_parser3` gem. Then it checks if the
openapi.yml file has been normalized via the `yaml_normalizer` gem. Also
adds a rakefile so the CI checks can be ran locally using the command
`bundle exec rake`.