### PR TITLE
Remove example

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -444,7 +444,6 @@ components:
           example: '2016-10-13T18:07:57.000Z'
           type: string
         challenges:
-          example: challenges
           items:
             "$ref": "#/components/schemas/Challenge"
           type: array


### PR DESCRIPTION
Removes temporary array example, as we now are generating nested
array/objects in our internal spec generator.