### PR TITLE
Correct statement endpoints

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -2052,7 +2052,7 @@ paths:
           description: OK
       summary: Fetch statements by member
       tags:
-      - Statement
+      - Member
   "/users/{user_guid}/members/{member_guid}/holdings":
     get:
       description: Use this endpoint to read all holdings associated with a specific


### PR DESCRIPTION
Fixes copy/paste error from `member` to `statement` on read statement
endpoint and accept header on the download pdf endpoint. Also corrects
tag on the fetch_statements endpoint.