### PR TITLE
Remove CI pull_request event

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,6 +1,6 @@
 name: Ruby
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   validate_openapi:


### PR DESCRIPTION
I noticed that were were runnining the CI 2 times when opening up a
merge request because it was triggered on `pull_request` and `push`
events. This reduces it to just the `push` event so the CI doesn't
run 2 times when opening up a pull request.