### PR TITLE
Fix typo

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -3332,7 +3332,98 @@ paths:
       summary: List transactions by tag
       tags:
       - Transaction
-  "/users/{user_guid}/transaction_rule/{transaction_rule_guid}":
+  "/users/{user_guid}/transaction_rules":
+    get:
+      description: Use this endpoint to read the attributes of all existing transaction
+        rules belonging to the user.
+      operationId: ListTransactionRulesByUser
+      parameters:
+      - description: Specify current page.
+        example: 1
+        in: query
+        name: page
+        schema:
+          type: integer
+      - description: Specify records per page.
+        example: 10
+        in: query
+        name: records_per_page
+        schema:
+          type: integer
+      - description: The unique id for a `user`.
+        example: USR-fa7537f3-48aa-a683-a02a-b18940482f54
+        in: path
+        name: user_guid
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/vnd.mx.api.v1+json:
+              schema:
+                properties:
+                  pagination:
+                    "$ref": "#/components/schemas/Pagination"
+                  transaction_rules:
+                    items:
+                      "$ref": "#/components/schemas/TransactionRule"
+                    type: array
+                type: object
+          description: OK
+      summary: List transaction rules by user
+      tags:
+      - TransactionRule
+    post:
+      description: Use this endpoint to create a new transaction rule. The newly-created
+        `transaction_rule` object will be returned if successful.
+      operationId: CreateTransactionRule
+      parameters:
+      - description: The unique id for a `user`.
+        example: USR-fa7537f3-48aa-a683-a02a-b18940482f54
+        in: path
+        name: user_guid
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                transaction_rule:
+                  properties:
+                    category_guid:
+                      example: CAT-b1de2a04-db08-b6ed-f6fe-ca2f5b11c2d0
+                      type: string
+                    description:
+                      example: Wal-mart food storage
+                      type: string
+                    match_description:
+                      example: Wal-mart
+                      type: string
+                  required:
+                  - category_guid
+                  - match_description
+                  type: object
+              type: object
+        description: TransactionRule object to be created with optional parameters
+          (description) and required parameters (category_guid and match_description)
+        required: true
+      responses:
+        '200':
+          content:
+            application/vnd.mx.api.v1+json:
+              schema:
+                properties:
+                  transaction_rule:
+                    "$ref": "#/components/schemas/TransactionRule"
+                type: object
+          description: OK
+      summary: Create transaction rule
+      tags:
+      - TransactionRule
+  "/users/{user_guid}/transaction_rules/{transaction_rule_guid}":
     delete:
       description: Use this endpoint to permanently delete a transaction rule based
         on its unique GUID.
@@ -3444,97 +3535,6 @@ paths:
                 type: object
           description: OK
       summary: Update transaction_rule
-      tags:
-      - TransactionRule
-  "/users/{user_guid}/transaction_rules":
-    get:
-      description: Use this endpoint to read the attributes of all existing transaction
-        rules belonging to the user.
-      operationId: ListTransactionRulesByUser
-      parameters:
-      - description: Specify current page.
-        example: 1
-        in: query
-        name: page
-        schema:
-          type: integer
-      - description: Specify records per page.
-        example: 10
-        in: query
-        name: records_per_page
-        schema:
-          type: integer
-      - description: The unique id for a `user`.
-        example: USR-fa7537f3-48aa-a683-a02a-b18940482f54
-        in: path
-        name: user_guid
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          content:
-            application/vnd.mx.api.v1+json:
-              schema:
-                properties:
-                  pagination:
-                    "$ref": "#/components/schemas/Pagination"
-                  transaction_rules:
-                    items:
-                      "$ref": "#/components/schemas/TransactionRule"
-                    type: array
-                type: object
-          description: OK
-      summary: List transaction rules by user
-      tags:
-      - TransactionRule
-    post:
-      description: Use this endpoint to create a new transaction rule. The newly-created
-        `transaction_rule` object will be returned if successful.
-      operationId: CreateTransactionRule
-      parameters:
-      - description: The unique id for a `user`.
-        example: USR-fa7537f3-48aa-a683-a02a-b18940482f54
-        in: path
-        name: user_guid
-        required: true
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              properties:
-                transaction_rule:
-                  properties:
-                    category_guid:
-                      example: CAT-b1de2a04-db08-b6ed-f6fe-ca2f5b11c2d0
-                      type: string
-                    description:
-                      example: Wal-mart food storage
-                      type: string
-                    match_description:
-                      example: Wal-mart
-                      type: string
-                  required:
-                  - category_guid
-                  - match_description
-                  type: object
-              type: object
-        description: TransactionRule object to be created with optional parameters
-          (description) and required parameters (category_guid and match_description)
-        required: true
-      responses:
-        '200':
-          content:
-            application/vnd.mx.api.v1+json:
-              schema:
-                properties:
-                  transaction_rule:
-                    "$ref": "#/components/schemas/TransactionRule"
-                type: object
-          description: OK
-      summary: Create transaction rule
       tags:
       - TransactionRule
   "/users/{user_guid}/transactions":


### PR DESCRIPTION
Adds an "s" to `/transaction_rule` path. That changed then shuffled the
file contents when running the normalize command.