### PR TITLE
Add beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,11 @@
+*This project is currently in **Beta**. Please open up an issue [here](https://github.com/mxenabled/openapi/issues) to report any differences in behavior between the MX Platform API and the OpenAPI specification.*
+
 # MX's OpenAPI Specification
 
-This repository contains the OpenAPI specification for the [MX Platform API](https://docs.mx.com).
-
-### Setup
-
-Run the command
-```
-bundle
-```
-to install the gems required to run the CI validations locally.
+This repository contains the OpenAPI specification for the [MX Platform API](https://docs.mx.com/api).
 
 ### Development
 
-After making changes to the `openapi.yml` file, running the command
-```
-bundle exec rake
-```
-will run the CI validations locally.
+Run the command `bundle` to install the gems required to run the CI validations locally.
+
+After making changes, running the command `bundle exec rake` will run the CI validations locally.


### PR DESCRIPTION
Adds Beta context to the top of the README so it's clear we are
currently in Beta. Also cleans up setup/development sections.