### PR TITLE
Move OAuth fields

### DIFF
--- a/openapi/mx_platform_api.yml
+++ b/openapi/mx_platform_api.yml
@@ -1897,19 +1897,19 @@ paths:
                     metadata:
                       example: '\"credentials_last_refreshed_at\": \"2015-10-15\"'
                       type: string
-                    referral_source:
-                      example: APP
-                      type: string
                     skip_aggregation:
                       example: false
                       type: boolean
-                    ui_message_webview_url_scheme:
-                      example: mx
-                      type: string
                   required:
                   - credentials
                   - institution_code
                   type: object
+                referral_source:
+                  example: APP
+                  type: string
+                ui_message_webview_url_scheme:
+                  example: mx
+                  type: string
               type: object
         description: Member object to be created with optional parameters (id and
           metadata) and required parameters (credentials and institution_code)


### PR DESCRIPTION
Moves OAuth fields out from the `"member"` hash to be siblings with it
instead. Usage shown in curl request example in the docs here:

https://press.qa.internal.mx/api#core_resources_members_create_member