### PR TITLE
Name array objects

### DIFF
--- a/openapi/mx_platform_api_beta.yml
+++ b/openapi/mx_platform_api_beta.yml
@@ -319,32 +319,14 @@ components:
           type: string
         image_options:
           items:
-            properties:
-              data_uri:
-                example: data:image/png;base64,iVBORw0KGgoAAAANSUh ... more image
-                  data ...
-                type: string
-              label:
-                example: IMAGE_1
-                type: string
-              value:
-                example: image_data
-                type: string
-            type: object
+            "$ref": "#/components/schemas/ImageOptionResponse"
           type: array
         label:
           example: Who is this guy?
           type: string
         options:
           items:
-            properties:
-              label:
-                example: IMAGE_1
-                type: string
-              value:
-                example: image_data
-                type: string
-            type: object
+            "$ref": "#/components/schemas/OptionResponse"
           type: array
         type:
           example: IMAGE_DATA
@@ -607,6 +589,18 @@ components:
         pagination:
           "$ref": "#/components/schemas/PaginationResponse"
       type: object
+    ImageOptionResponse:
+      properties:
+        data_uri:
+          example: data:image/png;base64,iVBORw0KGgoAAAANSUh ... more image data ...
+          type: string
+        label:
+          example: IMAGE_1
+          type: string
+        value:
+          example: image_data
+          type: string
+      type: object
     InstitutionResponse:
       properties:
         code:
@@ -866,6 +860,15 @@ components:
       properties:
         member:
           "$ref": "#/components/schemas/OAuthWindowResponse"
+      type: object
+    OptionResponse:
+      properties:
+        label:
+          example: IMAGE_1
+          type: string
+        value:
+          example: image_data
+          type: string
       type: object
     PaginationResponse:
       properties:


### PR DESCRIPTION
These array objects in the `ChallengeResponse` did not have an explicit
name previously. This gives them a name so the OpenAPI Generator no longer
produces one of it's own.