### PR TITLE
Remove accept header from 204 responses

### DIFF
--- a/openapi/mx_platform_api_beta.yml
+++ b/openapi/mx_platform_api_beta.yml
@@ -2526,9 +2526,6 @@ paths:
           type: string
       responses:
         '204':
-          content:
-            application/vnd.mx.api.v1+json:
-              example:
           description: No Content
       summary: Delete user
       tags:
@@ -2876,9 +2873,6 @@ paths:
           type: string
       responses:
         '204':
-          content:
-            application/vnd.mx.api.v1+json:
-              example:
           description: No Content
       summary: Delete category
       tags:
@@ -3140,9 +3134,6 @@ paths:
           type: string
       responses:
         '204':
-          content:
-            application/vnd.mx.api.v1+json:
-              example:
           description: No Content
       summary: Delete managed member
       tags:
@@ -3320,9 +3311,6 @@ paths:
           type: string
       responses:
         '204':
-          content:
-            application/vnd.mx.api.v1+json:
-              example:
           description: No Content
       summary: Delete managed account
       tags:
@@ -3513,9 +3501,6 @@ paths:
           type: string
       responses:
         '204':
-          content:
-            application/vnd.mx.api.v1+json:
-              example:
           description: No Content
       summary: Delete managed transaction
       tags:
@@ -3693,9 +3678,6 @@ paths:
           type: string
       responses:
         '204':
-          content:
-            application/vnd.mx.api.v1+json:
-              example:
           description: No Content
       summary: Delete member
       tags:
@@ -4602,9 +4584,6 @@ paths:
           type: string
       responses:
         '204':
-          content:
-            application/vnd.mx.api.v1+json:
-              example:
           description: No Content
       summary: Delete tagging
       tags:
@@ -4759,9 +4738,6 @@ paths:
           type: string
       responses:
         '204':
-          content:
-            application/vnd.mx.api.v1+json:
-              example:
           description: No Content
       summary: Delete tag
       tags:
@@ -4974,9 +4950,6 @@ paths:
           type: string
       responses:
         '204':
-          content:
-            application/vnd.mx.api.v1+json:
-              example:
           description: No Content
       summary: Delete transaction rule
       tags:


### PR DESCRIPTION
Running the old OpenAPI spec on the openapi generator 5.3.1 resulted in multiple libraries failing to generate and others defaulting the return type on 204 responses to "string". A "string" return type would be incorrect in the 204 case where no body is returned.

The old OpenAPI spec setup was used so we could have our required Accept header for the Platform API, as well as have no response body on our endpoints that return a 204. With the changes in 5.3.1 our old 204 response is no longer working.

The documented way to have no response body can be found [here](https://swagger.io/docs/specification/describing-responses/) and is what I have implemented on our 204 responses on this MR.

The issue with the documented method is that you can't have an accept header with the empty response body. So for now we will follow the documented method and have to use library methods to manually add in the required Accept header for endpoints that have a 204 response.

References:
https://swagger.io/docs/specification/describing-responses/
https://swagger.io/docs/specification/describing-parameters/
