### PR TITLE
readDefaultCategory should not have a user_guid argument

### DIFF
--- a/openapi/mx_platform_api.yml
+++ b/openapi/mx_platform_api.yml
@@ -2216,13 +2216,6 @@ paths:
         required: true
         schema:
           type: string
-      - description: The unique id for a `user`.
-        example: USR-fa7537f3-48aa-a683-a02a-b18940482f54
-        in: path
-        name: user_guid
-        required: true
-        schema:
-          type: string
       responses:
         '200':
           content:


### PR DESCRIPTION
I discovered this when generating for a rust project. I think we need to remove this arg?