### PR TITLE
adding holding_type_id

### DIFF
--- a/openapi/mx_platform_api.yml
+++ b/openapi/mx_platform_api.yml
@@ -716,6 +716,10 @@ components:
           example: MONEY_MARKET
           nullable: true
           type: string
+        holding_type_id:
+          example: 1
+          nullable: true
+          type: integer
         id:
           example: ID-123
           nullable: true


### PR DESCRIPTION
This adds the `holding_type_id` field to the spec for holdings. 