### PR TITLE
add disable_background_agg to widgetReq

### DIFF
--- a/openapi/mx_platform_api.yml
+++ b/openapi/mx_platform_api.yml
@@ -2145,6 +2145,9 @@ components:
         current_member_guid:
           example: MBR-7c6f361b-e582-15b6-60c0-358f12466b4b
           type: string
+        disable_background_agg:
+          example: false
+          type: boolean
         disable_institution_search:
           example: false
           type: boolean


### PR DESCRIPTION
RE: https://github.com/mxenabled/openapi/issues/83

Problem: https://github.com/mxenabled/openapi/pull/90 added disable_background_agg to the ConnectWidgetRequest but not the WidgetRequest

Solution: this adds disable_background_agg to WidgetRequest. With this change, WidgetRequest now contains every field that ConnectWidgetRequest has.