### PR TITLE
P1: Autogenerate client libraries on OpenAPI changes

### DIFF
--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -10,5 +10,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Trigger refresh of docs examples
+    - name: Refresh docs examples
       run: ${{ secrets.WEBHOOK_TRIGGERS }}

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,0 +1,29 @@
+name: Version
+
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+
+jobs:
+  Version:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v3
+      - name: Get openapi file
+        id: changed-files-specific
+        uses: tj-actions/changed-files@v35
+        with:
+          files: openapi/mx_platform_api.yml
+
+      - name: Require version label if openapi spec changed
+        if: steps.changed-files-specific.outputs.any_changed == 'true'
+        uses: mheap/github-action-required-labels@v4
+        with:
+          mode: exactly
+          count: 1
+          labels: "major, minor, patch"
+          add_comment: true
+          message: "This PR is blocked until you add one of the following labels: {{ provided }}. Once added you can merge."


### PR DESCRIPTION
This PR sets the base for being able to automate generating and publishing our client libraries from end-to-end based on changes made to the OpenAPI spec.

We will do this with a `version` action that first checks for changes made to the openapi spec and if so, we will then check for a `major`, `minor`, or `patch` label so that we can determine how to update the version for our libraries.