### PR TITLE
P2: Autogenerate libraries

### DIFF
--- a/.github/workflows/update_sdks.yml
+++ b/.github/workflows/update_sdks.yml
@@ -1,0 +1,38 @@
+name: Update SDKs
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  Update:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.merged }} == true && ${{ github.ref }} == 'refs/heads/master'
+    steps:
+      - uses: actions/checkout@v3
+      - name: Get openapi file
+        id: changed-files-specific
+        uses: tj-actions/changed-files@v35
+        with:
+          files: openapi/mx_platform_api.yml
+
+      - name: Generate access token
+        if: steps.changed-files-specific.outputs.any_changed == true
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.PAPI_SDK_APP_ID }}
+          installation_id: ${{ secrets.PAPI_SDK_INSTALLATION_ID }}
+          private_key: ${{ secrets.PAPI_SDK_PRIVATE_KEY }}
+
+      - name: Update libraries
+        env:
+          LABEL: ${{ github.event.pull_request.labels[0].name }}
+        if: env.LABEL == 'major' || env.LABEL == 'minor' || env.LABEL == 'patch' && steps.changed-files-specific.outputs.any_changed == true
+        run: |
+          curl \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: token ${{ steps.generate_token.outputs.token }}" \
+          https://api.github.com/repos/mxenabled/mx-platform-ruby/dispatches \
+          -d '{"event_type":"generate_publish_release","client_payload":{"version":"${{ env.LABEL }}"}}'


### PR DESCRIPTION
This builds off of [this PR](https://github.com/mxenabled/openapi/pull/100) to autogenerate our client libraries.

We will do this by utilizing a GitHub App so that we can kick off actions in the correct repos to generate and update our libraries when changes are made to the OpenAPI spec.