### PR TITLE
Remove changed file check

### DIFF
--- a/.github/workflows/update_sdks.yml
+++ b/.github/workflows/update_sdks.yml
@@ -17,7 +17,6 @@ jobs:
           files: openapi/mx_platform_api.yml
 
       - name: Generate access token
-        if: steps.changed-files-specific.outputs.any_changed == true
         id: generate_token
         uses: tibdex/github-app-token@v1
         with:


### PR DESCRIPTION
Removing the `if: steps.changed-files-specific.outputs.any_changed == true` check from the `Generate access token` step since we only need to make the check in the `Update libraries` step.