### PR TITLE
Specify workflows

### DIFF
--- a/.github/workflows/slack_notify.yml
+++ b/.github/workflows/slack_notify.yml
@@ -1,12 +1,12 @@
-name: Slack Notification
+name: Slack Notify
 
 on:
   issues:
     types:
       [opened, closed]
   workflow_run:
-    types:
-      [completed]
+    types: [completed]
+    workflows: [refresh, update_sdks]
 
 jobs:
   Notify:


### PR DESCRIPTION
Adds the required `workflows` field that allows us to specify which workflows we want to watch for and then send events for.