### PR TITLE
Refactor update_sdk workflow

### DIFF
--- a/.github/workflows/update_sdks.yml
+++ b/.github/workflows/update_sdks.yml
@@ -4,12 +4,12 @@ on:
   pull_request:
     types: [closed]
 
-env:
-  SDKS: "csharp,go,java,node,python,ruby"
-
 jobs:
   Update:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        repo: ["mxenabled/mx-platform-csharp", "mxenabled/mx-platform-go", "mxenabled/mx-platform-java", "mxenabled/mx-platform-node", "mxenabled/mx-platform-python", "mxenabled/mx-platform-ruby"]
     if: ${{ github.event.pull_request.merged }} == true && ${{ github.ref }} == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v3
@@ -29,15 +29,12 @@ jobs:
         env:
           LABEL: ${{ github.event.pull_request.labels[0].name }}
         if: env.LABEL == 'major' || env.LABEL == 'minor' || env.LABEL == 'patch' && steps.changed-files-specific.outputs.any_changed == true
-        run: |
-          for sdk in $(echo $SDKS | tr ',' ' '); do
-            curl \
-            -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: token ${{ steps.generate_token.outputs.token }}" \
-            https://api.github.com/repos/mxenabled/mx-platform-$sdk/dispatches \
-            -d '{"event_type":"generate_publish_release","client_payload":{"version":"${{ env.LABEL }}"}}'
-          done
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ steps.generate_token.outputs.token }}
+          repository: ${{ matrix.repo }}
+          event-type: generate_publish_release
+          client-payload: '{"version":"${{ env.LABEL }}"}'
       - name: Slack notification
         uses: ravsamhq/notify-slack-action@v2
         if: always()


### PR DESCRIPTION
This refactors the `update_sdk` workflow by utilizing a github action for the repository dispatch events.