### PR TITLE
Add missing fields to MemberResponse

### DIFF
--- a/openapi/mx_platform_api.yml
+++ b/openapi/mx_platform_api.yml
@@ -1661,6 +1661,14 @@ components:
           example: '\"credentials_last_refreshed_at\": \"2015-10-15\"'
           nullable: true
           type: string
+        most_recent_job_detail_code:
+          example: (deprecated)
+          nullable: true
+          type: string
+        most_recent_job_detail_text:
+          example: (deprecated)
+          nullable: true
+          type: string
         name:
           example: Chase Bank
           nullable: true

--- a/openapi/mx_platform_api.yml
+++ b/openapi/mx_platform_api.yml
@@ -1653,6 +1653,10 @@ components:
           example: false
           nullable: true
           type: boolean
+        is_manual:
+          example: false
+          nullable: true
+          type: boolean
         is_oauth:
           example: false
           nullable: true


### PR DESCRIPTION
Resolves: https://mxcom.atlassian.net/browse/DEVX-839

document missing fields in the MemberResponse:
`is_manual`
`most_recent_job_detail_code`
`most_recent_job_detail_text`

These fields are documented in the MX docs for the `resume` endpoint : https://docs.mx.com/api-reference/platform-api/reference/resume-aggregation