### PR TITLE
Update v2011 OAS file, Add Automation Variable for Multi-Version

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -11,7 +11,6 @@ on:
         default: "patch"
         type: choice
         options:
-        - major
         - minor
         - patch
 
@@ -39,13 +38,13 @@ jobs:
       - name: Update libraries
         env:
           LABEL: ${{ github.event.pull_request.labels[0].name }}
-        if: env.LABEL == 'major' || env.LABEL == 'minor' || env.LABEL == 'patch' && steps.changed-files-specific.outputs.any_changed == true
+        if: env.LABEL == 'minor' || env.LABEL == 'patch' && steps.changed-files-specific.outputs.any_changed == true
         uses: peter-evans/repository-dispatch@v2
         with:
           token: ${{ steps.generate_token.outputs.token }}
           repository: ${{ matrix.repo }}
           event-type: generate_publish_release
-          client-payload: '{"version":"${{ env.LABEL }}"}'
+          client-payload: '{"version":"${{ env.LABEL }}","commit_sha":"${{ github.sha }}"}'
       - name: Slack notification
         uses: ravsamhq/notify-slack-action@v2
         if: always()
@@ -79,7 +78,7 @@ jobs:
           token: ${{ steps.generate_token.outputs.token }}
           repository: ${{ matrix.repo }}
           event-type: generate_publish_release
-          client-payload: '{"version":"${{ github.event.inputs.version_level }}"}'
+          client-payload: '{"version":"${{ github.event.inputs.version_level }}","commit_sha":"${{ github.sha }}"}'
       - name: Slack notification
         uses: ravsamhq/notify-slack-action@v2
         if: always()

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -24,6 +24,6 @@ jobs:
         with:
           mode: exactly
           count: 1
-          labels: "major, minor, patch"
+          labels: "minor, patch"
           add_comment: true
           message: "This PR is blocked until you add one of the following labels: {{ provided }}. Once added you can merge."

--- a/openapi/mx_platform_api.yml
+++ b/openapi/mx_platform_api.yml
@@ -178,7 +178,7 @@ paths:
         - $ref: '#/components/parameters/institutionName'
         - $ref: '#/components/parameters/isoCountryCode'
         - $ref: '#/components/parameters/page'
-        - $ref: '#/components/parameters/recordsPerPage'
+        - $ref: '#/components/parameters/recordsPerPageMax1000'
         - $ref: '#/components/parameters/supportsAccountIdentification'
         - $ref: '#/components/parameters/supportsAccountStatement'
         - $ref: '#/components/parameters/supportsAccountVerification'
@@ -200,7 +200,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/isoCountryCode'
         - $ref: '#/components/parameters/page'
-        - $ref: '#/components/parameters/recordsPerPage'
+        - $ref: '#/components/parameters/recordsPerPageMax1000'
       responses:
         '200':
           content:
@@ -339,7 +339,7 @@ paths:
         - processor token
   /transactions/enhance:
     post:
-      description: "Use this endpoint to categorize, cleanse, and classify transactions. These transactions are not persisted or stored on the MX platform. <br /><br />For more information on returned data, please see the [Enhanced Transactions fields guide](/api-reference/platform-api/reference/transactions-overview#enhanced-transactions)."
+      description: "Use this endpoint to categorize, cleanse, and classify transactions. These transactions are not  persisted or stored on the MX platform. <br /><br />For more information on returned data, please  see the [Enhanced Transactions fields guide](/api-reference/platform-api/reference/transactions-overview#enhanced-transactions)."
       operationId: enhanceTransactions
       requestBody:
         content:
@@ -404,7 +404,7 @@ paths:
         Use this endpoint to delete the specified `user`. The response will have a status of `204 No Content` without an object.
 
         :::warning
-        Deleting a user is permanent. Deleted users can never be restored. For more info, see [Deleting Objects](https://docs.mx.com/api-reference/platform-api/overview/deleting-objects).
+        Deleting a user is permanent. Deleted users can never be restored. For more info, see [Deleting Objects](/api-reference/platform-api/overview/deleting-objects).
         :::
       operationId: deleteUser
       parameters:
@@ -459,7 +459,7 @@ paths:
         This endpoint returns a list of all the accounts associated with the specified `user`.
 
         :::warning
-        This request will not return the full account number. It may return the last four digits of the account number if that information has been provided during aggregation. If you need the full account number, please refer to [List account numbers by member](https://docs.mx.com/api-reference/platform-api/reference/list-account-numbers-by-member/), [List account numbers by account](https://docs.mx.com/api-reference/platform-api/reference/list-account-numbers-by-account/), or the [Fetch Account and Routing Numbers](https://docs.mx.com/products/connectivity/instant-account-verification/fetch-account-routing-number-api/#4-read-the-account-numbers) guide.
+        This request will not return the full account number. It may return the last four digits of the account number if that information has been provided during aggregation. If you need the full account number, please refer to [List account numbers by member](/api-reference/platform-api/reference/list-account-numbers-by-member/) or [List account numbers by account](/api-reference/platform-api/reference/list-account-numbers-by-account/).
         :::
       operationId: listUserAccounts
       parameters:
@@ -593,7 +593,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/TransactionCreateResponseBody'
     get:
-      description: "Requests to this endpoint return a list of transactions associated with the specified account. <br /><br />Enhanced transaction data may be requested using the `includes` parameter. To use this optional parameter, the value should include the optional metadata requested such as `repeating_transactions`, `merchants`, `classifications`, `geolocations`. For more information, see the [Optional Enhancement Query Parameter guide](/api-reference/platform-api/reference/transactions-overview#enhanced-transactions#optional-enhancement-query-parameter)."
+      description: "Requests to this endpoint return a list of transactions associated with the specified account. <br /><br /> Enhanced transaction data may be requested using the `includes` parameter. To use this optional parameter,  the value should include the optional metadata requested such as `repeating_transactions`, `merchants`,  `classifications`, `geolocations`. For more information, see the [Optional Enhancement Query Parameter guide](/api-reference/platform-api/reference/transactions-overview#enhanced-transactions#optional-enhancement-query-parameter)."
       operationId: listTransactionsByAccount
       parameters:
         - $ref: '#/components/parameters/accountGuid'
@@ -1764,7 +1764,7 @@ paths:
         - members
   /users/{user_guid}/members/{member_guid}/transactions:
     get:
-      description: "Requests to this endpoint return a list of transactions associated with the specified `member`, across all accounts associated with that `member`. <br /><br />Enhanced transaction data may be requested using the `includes` parameter. To use this optional parameter, the value should include the optional metadata requested such as `repeating_transactions`, `merchants`, `classifications`, `geolocations`. For more information, see the [Optional Enhancement Query Parameter guide](/api-reference/platform-api/reference/transactions-overview#enhanced-transactions#optional-enhancement-query-parameter)."
+      description: "Requests to this endpoint return a list of transactions associated with the specified  `member`, across all accounts associated with that `member`. <br /><br />Enhanced transaction data  may be requested using the `includes` parameter. To use this optional parameter, the value should  include the optional metadata requested such as `repeating_transactions`, `merchants`, `classifications`,  `geolocations`. For more information, see the [Optional Enhancement Query Parameter guide](/api-reference/platform-api/reference/transactions-overview#enhanced-transactions#optional-enhancement-query-parameter)."
       operationId: listTransactionsByMember
       parameters:
         - $ref: '#/components/parameters/memberGuid'
@@ -2270,7 +2270,7 @@ paths:
         - tags
   /users/{user_guid}/tags/{tag_guid}/transactions:
     get:
-      description: "Use this endpoint to get a list of all transactions associated with a particular tag according to the tag's unique GUID. This lists all transactions that have been assigned to a particular tag using the create tagging endpoint. <br /><br />Enhanced transaction data may be requested using the `includes` parameter. To use this optional parameter, the value should include the optional metadata requested such as `repeating_transactions`, `merchants`, `classifications`, `geolocations`. For more information, see the [Optional Enhancement Query Parameter guide](/api-reference/platform-api/reference/transactions-overview#enhanced-transactions#optional-enhancement-query-parameter)."
+      description: "Use this endpoint to get a list of all transactions associated with a particular tag  according to the tag's unique GUID. This lists all transactions that have been assigned to a particular  tag using the create tagging endpoint. <br /><br />Enhanced transaction data may be requested using the  `includes` parameter. To use this optional parameter, the value should include the optional metadata  requested such as `repeating_transactions`, `merchants`, `classifications`, `geolocations`. For more  information, see the [Optional Enhancement Query Parameter guide](/api-reference/platform-api/reference/transactions-overview#enhanced-transactions#optional-enhancement-query-parameter)."
       operationId: listTransactionsByTag
       parameters:
         - $ref: '#/components/parameters/userGuid'
@@ -2393,7 +2393,7 @@ paths:
         - transaction rules
   /users/{user_guid}/transactions:
     get:
-      description: "Requests to this endpoint return a list of transactions associated with the specified `user`, across all members and accounts associated with that `user`. <br /><br />Enhanced transaction data may be requested using the `includes` parameter. To use this optional parameter, the value should include the optional metadata requested such as `repeating_transactions`, `merchants`, `classifications`, `geolocations`. For more information, see the [Optional Enhancement Query Parameter guide](/api-reference/platform-api/reference/transactions-overview#enhanced-transactions#optional-enhancement-query-parameter)."
+      description: "Requests to this endpoint return a list of transactions associated with the specified  `user`, across all members and accounts associated with that `user`. <br /><br />Enhanced transaction  data may be requested using the `includes` parameter. To use this optional parameter, the value should  include the optional metadata requested such as `repeating_transactions`, `merchants`, `classifications`,  `geolocations`. For more information, see the [Optional Enhancement Query Parameter guide](/api-reference/platform-api/reference/transactions-overview#enhanced-transactions#optional-enhancement-query-parameter)."
       operationId: listTransactions
       parameters:
         - $ref: '#/components/parameters/userGuid'
@@ -2426,7 +2426,7 @@ paths:
       - $ref: '#/components/parameters/userGuid'
       - $ref: '#/components/parameters/transactionGuid'
     get:
-      description: "Requests to this endpoint will return the attributes of the specified `transaction`. To read a manual transaction, use the manual transaction guid in the path as the `transactionGuid`. <br /><br />Enhanced transaction data may be requested using the `includes` parameter. To use this optional parameter, the value should include the optional metadata requested such as `repeating_transactions`, `merchants`, `classifications`, `geolocations`. For more information, see the [Optional Enhancement Query Parameter guide](/api-reference/platform-api/reference/transactions-overview#enhanced-transactions#optional-enhancement-query-parameter)."
+      description: "Requests to this endpoint will return the attributes of the specified `transaction`. To  read a manual transaction, use the manual transaction guid in the path as the `transactionGuid`. <br /><br /> Enhanced transaction data may be requested using the `includes` parameter. To use this optional parameter,  the value should include the optional metadata requested such as `repeating_transactions`, `merchants`,  `classifications`, `geolocations`. For more information, see the [Optional Enhancement Query Parameter guide](/api-reference/platform-api/reference/transactions-overview#enhanced-transactions#optional-enhancement-query-parameter)."
       operationId: readTransaction
       responses:
         '200':
@@ -2763,7 +2763,7 @@ paths:
                 $ref: '#/components/schemas/NotificationResponseBody'
   /users/{user_guid}/repeating_transactions:
     get:
-      description: "Retrieve a list of all recurring transactions for a user. <br /><br />For more see the [Repeating Transactions guide](repeating-transactions-overview.mdx)."
+      description: "Retrieve a list of all recurring transactions for a user. <br /><br />For more see the [Repeating Transactions guide](/api-reference/platform-api/v20111101/reference/transactions-overview#repeating-transactions)."
       operationId: repeatingTransactions
       parameters:
         - $ref: '#/components/parameters/userGuid'
@@ -2779,7 +2779,7 @@ paths:
         - transactions
   /users/{user_guid}/repeating_transactions/{repeating_transaction_guid}:
     get:
-      description: "Get a Specific Repeating Transaction. <br /><br />List For more see the [Repeating Transactions guide](repeating-transactions-overview.mdx)"
+      description: "Get a Specific Repeating Transaction. <br /><br />List For more see the  [Repeating Transactions guide](/api-reference/platform-api/v20111101/reference/transactions-overview#repeating-transactions)"
       operationId: specificRepeatingTransaction
       parameters:
         - $ref: '#/components/parameters/userGuid'
@@ -3023,7 +3023,7 @@ paths:
         - microdeposits
       operationId: readUserMicrodeposit
       summary: Read a microdeposit for a user
-      description: "Use this endpoint to read the attributes of a specific microdeposit according to its unique GUID. <br /><br /> Webhooks for microdeposit status changes are triggered when a status changes. The actual status of the microdeposit guid updates every minute. You may force a status update by calling the read microdeposit endpoint."
+      description: "Use this endpoint to read the attributes of a specific microdeposit according to its  unique GUID. <br></br> Webhooks for microdeposit status changes are triggered when a  status changes. The actual status of the microdeposit guid updates every minute. You may  force a status update by calling the read microdeposit endpoint."
       responses:
         '200':
           description: OK
@@ -3519,6 +3519,7 @@ components:
           nullable: true
           type: string
         instructional_text:
+          description: "Render this text when end users are asked for their credentials, as it helps end users provide the correct credentials when creating a new member. May contain `<a></a>` tags to link to explanatory material."
           example: "Some instructional text <a href=\"https://example.url.mxbank.com/instructions\" id=\"instructional_text\">for end users</a>."
           nullable: true
           type: string
@@ -6979,7 +6980,7 @@ components:
           example: false
           type: boolean
           description: |
-            Only use this option if the `widget_type` is set to `connect_widget`. This determines whether the institution search is displayed within the Connect Widget. This option must be used with `current_institution_code`, `current_instituion_guid`, or `current_member_guid`. When set to `true`, the institution search feature will be disabled and end users will not be able to navigate to it. Defaults to `false`.
+            Only use this option if the `widget_type` is set to `connect_widget`. This determines whether the institution search is displayed within the Connect Widget. This option must be used with `current_institution_code`, `current_instituion_guid`, or `current_member_guid`. When set to `true`, the institution search feature will be disabled and end users will not be able to navigate to it. Defaults to `false`. If you set `disable_institution_search` to `true`, you must also listen for the [backToSearch event](/connect/guides/handling-events/#back-to-search) to intercept the user from navigating back to search during the flow. Don't listen for any Primary Action postMessages when you disable search.  All buttons that will take a user to the search institution page are still displayed in the Connect Widget experience and your user can still select them. This may trigger during several steps in the Connect Widget flow, such as Connected, MDV/Microdeposits Verified, Login Error, and Credentials/OAuth (back button).
         enable_app2app:
           example: false
           type: boolean
@@ -8062,6 +8063,13 @@ components:
         type: array
         items:
           type: string
+    recordsPerPageMax1000:
+      description: This specifies the number of records to be returned on each page. Defaults to `25`. The valid range is from `10` to `1000`. If the value exceeds `1000`, the default value of `25` will be used instead.
+      example: 10
+      in: query
+      name: records_per_page
+      schema:
+        type: integer
     supportsAccountIdentification:
       description: Filter only institutions which support account identification.
       example: true
@@ -8098,13 +8106,6 @@ components:
       required: true
       schema:
         type: string
-    recordsPerPageMax1000:
-      description: This specifies the number of records to be returned on each page. Defaults to `25`. The valid range is from `10` to `1000`. If the value exceeds `1000`, the default value of `25` will be used instead.
-      example: 10
-      in: query
-      name: records_per_page
-      schema:
-        type: integer
     merchantLocationGuid:
       description: The unique id for a `merchant_location`.
       example: MCH-09466f0a-fb58-9d1a-bae2-2af0afbea621

--- a/openapi/mx_platform_api.yml
+++ b/openapi/mx_platform_api.yml
@@ -339,7 +339,7 @@ paths:
         - processor token
   /transactions/enhance:
     post:
-      description: "Use this endpoint to categorize, cleanse, and classify transactions. These transactions are not  persisted or stored on the MX platform. <br /><br />For more information on returned data, please  see the [Enhanced Transactions fields guide](/api-reference/platform-api/reference/transactions-overview#enhanced-transactions)."
+      description: "Use this endpoint to categorize, cleanse, and classify transactions. These transactions are not persisted or stored on the MX platform. <br /><br />For more information on returned data, please see the [Enhanced Transactions fields guide](/api-reference/platform-api/reference/transactions-overview#enhanced-transactions)."
       operationId: enhanceTransactions
       requestBody:
         content:
@@ -593,7 +593,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/TransactionCreateResponseBody'
     get:
-      description: "Requests to this endpoint return a list of transactions associated with the specified account. <br /><br /> Enhanced transaction data may be requested using the `includes` parameter. To use this optional parameter,  the value should include the optional metadata requested such as `repeating_transactions`, `merchants`,  `classifications`, `geolocations`. For more information, see the [Optional Enhancement Query Parameter guide](/api-reference/platform-api/reference/transactions-overview#enhanced-transactions#optional-enhancement-query-parameter)."
+      description: "Requests to this endpoint return a list of transactions associated with the specified account. <br /><br /> Enhanced transaction data may be requested using the `includes` parameter. To use this optional parameter, the value should include the optional metadata requested such as `repeating_transactions`, `merchants`, `classifications`, `geolocations`. For more information, see the [Optional Enhancement Query Parameter guide](/api-reference/platform-api/reference/transactions-overview#enhanced-transactions#optional-enhancement-query-parameter)."
       operationId: listTransactionsByAccount
       parameters:
         - $ref: '#/components/parameters/accountGuid'
@@ -1764,7 +1764,7 @@ paths:
         - members
   /users/{user_guid}/members/{member_guid}/transactions:
     get:
-      description: "Requests to this endpoint return a list of transactions associated with the specified  `member`, across all accounts associated with that `member`. <br /><br />Enhanced transaction data  may be requested using the `includes` parameter. To use this optional parameter, the value should  include the optional metadata requested such as `repeating_transactions`, `merchants`, `classifications`,  `geolocations`. For more information, see the [Optional Enhancement Query Parameter guide](/api-reference/platform-api/reference/transactions-overview#enhanced-transactions#optional-enhancement-query-parameter)."
+      description: "Requests to this endpoint return a list of transactions associated with the specified `member`, across all accounts associated with that `member`. <br /><br />Enhanced transaction data may be requested using the `includes` parameter. To use this optional parameter, the value should include the optional metadata requested such as `repeating_transactions`, `merchants`, `classifications`, `geolocations`. For more information, see the [Optional Enhancement Query Parameter guide](/api-reference/platform-api/reference/transactions-overview#enhanced-transactions#optional-enhancement-query-parameter)."
       operationId: listTransactionsByMember
       parameters:
         - $ref: '#/components/parameters/memberGuid'
@@ -2270,7 +2270,7 @@ paths:
         - tags
   /users/{user_guid}/tags/{tag_guid}/transactions:
     get:
-      description: "Use this endpoint to get a list of all transactions associated with a particular tag  according to the tag's unique GUID. This lists all transactions that have been assigned to a particular  tag using the create tagging endpoint. <br /><br />Enhanced transaction data may be requested using the  `includes` parameter. To use this optional parameter, the value should include the optional metadata  requested such as `repeating_transactions`, `merchants`, `classifications`, `geolocations`. For more  information, see the [Optional Enhancement Query Parameter guide](/api-reference/platform-api/reference/transactions-overview#enhanced-transactions#optional-enhancement-query-parameter)."
+      description: "Use this endpoint to get a list of all transactions associated with a particular tag according to the tag's unique GUID. This lists all transactions that have been assigned to a particular tag using the create tagging endpoint. <br /><br />Enhanced transaction data may be requested using the `includes` parameter. To use this optional parameter, the value should include the optional metadata requested such as `repeating_transactions`, `merchants`, `classifications`, `geolocations`. For more information, see the [Optional Enhancement Query Parameter guide](/api-reference/platform-api/reference/transactions-overview#enhanced-transactions#optional-enhancement-query-parameter)."
       operationId: listTransactionsByTag
       parameters:
         - $ref: '#/components/parameters/userGuid'
@@ -2393,7 +2393,7 @@ paths:
         - transaction rules
   /users/{user_guid}/transactions:
     get:
-      description: "Requests to this endpoint return a list of transactions associated with the specified  `user`, across all members and accounts associated with that `user`. <br /><br />Enhanced transaction  data may be requested using the `includes` parameter. To use this optional parameter, the value should  include the optional metadata requested such as `repeating_transactions`, `merchants`, `classifications`,  `geolocations`. For more information, see the [Optional Enhancement Query Parameter guide](/api-reference/platform-api/reference/transactions-overview#enhanced-transactions#optional-enhancement-query-parameter)."
+      description: "Requests to this endpoint return a list of transactions associated with the specified `user`, across all members and accounts associated with that `user`. <br /><br />Enhanced transaction data may be requested using the `includes` parameter. To use this optional parameter, the value should include the optional metadata requested such as `repeating_transactions`, `merchants`, `classifications`, `geolocations`. For more information, see the [Optional Enhancement Query Parameter guide](/api-reference/platform-api/reference/transactions-overview#enhanced-transactions#optional-enhancement-query-parameter)."
       operationId: listTransactions
       parameters:
         - $ref: '#/components/parameters/userGuid'
@@ -2426,7 +2426,7 @@ paths:
       - $ref: '#/components/parameters/userGuid'
       - $ref: '#/components/parameters/transactionGuid'
     get:
-      description: "Requests to this endpoint will return the attributes of the specified `transaction`. To  read a manual transaction, use the manual transaction guid in the path as the `transactionGuid`. <br /><br /> Enhanced transaction data may be requested using the `includes` parameter. To use this optional parameter,  the value should include the optional metadata requested such as `repeating_transactions`, `merchants`,  `classifications`, `geolocations`. For more information, see the [Optional Enhancement Query Parameter guide](/api-reference/platform-api/reference/transactions-overview#enhanced-transactions#optional-enhancement-query-parameter)."
+      description: "Requests to this endpoint will return the attributes of the specified `transaction`. To read a manual transaction, use the manual transaction guid in the path as the `transactionGuid`. <br /><br /> Enhanced transaction data may be requested using the `includes` parameter. To use this optional parameter, the value should include the optional metadata requested such as `repeating_transactions`, `merchants`, `classifications`, `geolocations`. For more information, see the [Optional Enhancement Query Parameter guide](/api-reference/platform-api/reference/transactions-overview#enhanced-transactions#optional-enhancement-query-parameter)."
       operationId: readTransaction
       responses:
         '200':
@@ -3023,7 +3023,7 @@ paths:
         - microdeposits
       operationId: readUserMicrodeposit
       summary: Read a microdeposit for a user
-      description: "Use this endpoint to read the attributes of a specific microdeposit according to its  unique GUID. <br></br> Webhooks for microdeposit status changes are triggered when a  status changes. The actual status of the microdeposit guid updates every minute. You may  force a status update by calling the read microdeposit endpoint."
+      description: "Use this endpoint to read the attributes of a specific microdeposit according to its unique GUID. <br></br> Webhooks for microdeposit status changes are triggered when a status changes. The actual status of the microdeposit guid updates every minute. You may force a status update by calling the read microdeposit endpoint."
       responses:
         '200':
           description: OK

--- a/openapi/v20111101.yml
+++ b/openapi/v20111101.yml
@@ -339,7 +339,7 @@ paths:
         - processor token
   /transactions/enhance:
     post:
-      description: "Use this endpoint to categorize, cleanse, and classify transactions. These transactions are not  persisted or stored on the MX platform. <br /><br />For more information on returned data, please  see the [Enhanced Transactions fields guide](/api-reference/platform-api/reference/transactions-overview#enhanced-transactions)."
+      description: "Use this endpoint to categorize, cleanse, and classify transactions. These transactions are not persisted or stored on the MX platform. <br /><br />For more information on returned data, please see the [Enhanced Transactions fields guide](/api-reference/platform-api/reference/transactions-overview#enhanced-transactions)."
       operationId: enhanceTransactions
       requestBody:
         content:
@@ -593,7 +593,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/TransactionCreateResponseBody'
     get:
-      description: "Requests to this endpoint return a list of transactions associated with the specified account. <br /><br /> Enhanced transaction data may be requested using the `includes` parameter. To use this optional parameter,  the value should include the optional metadata requested such as `repeating_transactions`, `merchants`,  `classifications`, `geolocations`. For more information, see the [Optional Enhancement Query Parameter guide](/api-reference/platform-api/reference/transactions-overview#enhanced-transactions#optional-enhancement-query-parameter)."
+      description: "Requests to this endpoint return a list of transactions associated with the specified account. <br /><br /> Enhanced transaction data may be requested using the `includes` parameter. To use this optional parameter, the value should include the optional metadata requested such as `repeating_transactions`, `merchants`, `classifications`, `geolocations`. For more information, see the [Optional Enhancement Query Parameter guide](/api-reference/platform-api/reference/transactions-overview#enhanced-transactions#optional-enhancement-query-parameter)."
       operationId: listTransactionsByAccount
       parameters:
         - $ref: '#/components/parameters/accountGuid'
@@ -1764,7 +1764,7 @@ paths:
         - members
   /users/{user_guid}/members/{member_guid}/transactions:
     get:
-      description: "Requests to this endpoint return a list of transactions associated with the specified  `member`, across all accounts associated with that `member`. <br /><br />Enhanced transaction data  may be requested using the `includes` parameter. To use this optional parameter, the value should  include the optional metadata requested such as `repeating_transactions`, `merchants`, `classifications`,  `geolocations`. For more information, see the [Optional Enhancement Query Parameter guide](/api-reference/platform-api/reference/transactions-overview#enhanced-transactions#optional-enhancement-query-parameter)."
+      description: "Requests to this endpoint return a list of transactions associated with the specified `member`, across all accounts associated with that `member`. <br /><br />Enhanced transaction data may be requested using the `includes` parameter. To use this optional parameter, the value should include the optional metadata requested such as `repeating_transactions`, `merchants`, `classifications`, `geolocations`. For more information, see the [Optional Enhancement Query Parameter guide](/api-reference/platform-api/reference/transactions-overview#enhanced-transactions#optional-enhancement-query-parameter)."
       operationId: listTransactionsByMember
       parameters:
         - $ref: '#/components/parameters/memberGuid'
@@ -2270,7 +2270,7 @@ paths:
         - tags
   /users/{user_guid}/tags/{tag_guid}/transactions:
     get:
-      description: "Use this endpoint to get a list of all transactions associated with a particular tag  according to the tag's unique GUID. This lists all transactions that have been assigned to a particular  tag using the create tagging endpoint. <br /><br />Enhanced transaction data may be requested using the  `includes` parameter. To use this optional parameter, the value should include the optional metadata  requested such as `repeating_transactions`, `merchants`, `classifications`, `geolocations`. For more  information, see the [Optional Enhancement Query Parameter guide](/api-reference/platform-api/reference/transactions-overview#enhanced-transactions#optional-enhancement-query-parameter)."
+      description: "Use this endpoint to get a list of all transactions associated with a particular tag according to the tag's unique GUID. This lists all transactions that have been assigned to a particular tag using the create tagging endpoint. <br /><br />Enhanced transaction data may be requested using the `includes` parameter. To use this optional parameter, the value should include the optional metadata requested such as `repeating_transactions`, `merchants`, `classifications`, `geolocations`. For more information, see the [Optional Enhancement Query Parameter guide](/api-reference/platform-api/reference/transactions-overview#enhanced-transactions#optional-enhancement-query-parameter)."
       operationId: listTransactionsByTag
       parameters:
         - $ref: '#/components/parameters/userGuid'
@@ -2393,7 +2393,7 @@ paths:
         - transaction rules
   /users/{user_guid}/transactions:
     get:
-      description: "Requests to this endpoint return a list of transactions associated with the specified  `user`, across all members and accounts associated with that `user`. <br /><br />Enhanced transaction  data may be requested using the `includes` parameter. To use this optional parameter, the value should  include the optional metadata requested such as `repeating_transactions`, `merchants`, `classifications`,  `geolocations`. For more information, see the [Optional Enhancement Query Parameter guide](/api-reference/platform-api/reference/transactions-overview#enhanced-transactions#optional-enhancement-query-parameter)."
+      description: "Requests to this endpoint return a list of transactions associated with the specified `user`, across all members and accounts associated with that `user`. <br /><br />Enhanced transaction data may be requested using the `includes` parameter. To use this optional parameter, the value should include the optional metadata requested such as `repeating_transactions`, `merchants`, `classifications`, `geolocations`. For more information, see the [Optional Enhancement Query Parameter guide](/api-reference/platform-api/reference/transactions-overview#enhanced-transactions#optional-enhancement-query-parameter)."
       operationId: listTransactions
       parameters:
         - $ref: '#/components/parameters/userGuid'
@@ -2426,7 +2426,7 @@ paths:
       - $ref: '#/components/parameters/userGuid'
       - $ref: '#/components/parameters/transactionGuid'
     get:
-      description: "Requests to this endpoint will return the attributes of the specified `transaction`. To  read a manual transaction, use the manual transaction guid in the path as the `transactionGuid`. <br /><br /> Enhanced transaction data may be requested using the `includes` parameter. To use this optional parameter,  the value should include the optional metadata requested such as `repeating_transactions`, `merchants`,  `classifications`, `geolocations`. For more information, see the [Optional Enhancement Query Parameter guide](/api-reference/platform-api/reference/transactions-overview#enhanced-transactions#optional-enhancement-query-parameter)."
+      description: "Requests to this endpoint will return the attributes of the specified `transaction`. To read a manual transaction, use the manual transaction guid in the path as the `transactionGuid`. <br /><br /> Enhanced transaction data may be requested using the `includes` parameter. To use this optional parameter, the value should include the optional metadata requested such as `repeating_transactions`, `merchants`, `classifications`, `geolocations`. For more information, see the [Optional Enhancement Query Parameter guide](/api-reference/platform-api/reference/transactions-overview#enhanced-transactions#optional-enhancement-query-parameter)."
       operationId: readTransaction
       responses:
         '200':
@@ -3023,7 +3023,7 @@ paths:
         - microdeposits
       operationId: readUserMicrodeposit
       summary: Read a microdeposit for a user
-      description: "Use this endpoint to read the attributes of a specific microdeposit according to its  unique GUID. <br></br> Webhooks for microdeposit status changes are triggered when a  status changes. The actual status of the microdeposit guid updates every minute. You may  force a status update by calling the read microdeposit endpoint."
+      description: "Use this endpoint to read the attributes of a specific microdeposit according to its unique GUID. <br></br> Webhooks for microdeposit status changes are triggered when a status changes. The actual status of the microdeposit guid updates every minute. You may force a status update by calling the read microdeposit endpoint."
       responses:
         '200':
           description: OK

--- a/openapi/v20111101.yml
+++ b/openapi/v20111101.yml
@@ -178,7 +178,7 @@ paths:
         - $ref: '#/components/parameters/institutionName'
         - $ref: '#/components/parameters/isoCountryCode'
         - $ref: '#/components/parameters/page'
-        - $ref: '#/components/parameters/recordsPerPage'
+        - $ref: '#/components/parameters/recordsPerPageMax1000'
         - $ref: '#/components/parameters/supportsAccountIdentification'
         - $ref: '#/components/parameters/supportsAccountStatement'
         - $ref: '#/components/parameters/supportsAccountVerification'
@@ -200,7 +200,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/isoCountryCode'
         - $ref: '#/components/parameters/page'
-        - $ref: '#/components/parameters/recordsPerPage'
+        - $ref: '#/components/parameters/recordsPerPageMax1000'
       responses:
         '200':
           content:
@@ -339,7 +339,7 @@ paths:
         - processor token
   /transactions/enhance:
     post:
-      description: "Use this endpoint to categorize, cleanse, and classify transactions. These transactions are not persisted or stored on the MX platform. <br /><br />For more information on returned data, please see the [Enhanced Transactions fields guide](/api-reference/platform-api/reference/transactions-overview#enhanced-transactions)."
+      description: "Use this endpoint to categorize, cleanse, and classify transactions. These transactions are not  persisted or stored on the MX platform. <br /><br />For more information on returned data, please  see the [Enhanced Transactions fields guide](/api-reference/platform-api/reference/transactions-overview#enhanced-transactions)."
       operationId: enhanceTransactions
       requestBody:
         content:
@@ -404,7 +404,7 @@ paths:
         Use this endpoint to delete the specified `user`. The response will have a status of `204 No Content` without an object.
 
         :::warning
-        Deleting a user is permanent. Deleted users can never be restored. For more info, see [Deleting Objects](https://docs.mx.com/api-reference/platform-api/overview/deleting-objects).
+        Deleting a user is permanent. Deleted users can never be restored. For more info, see [Deleting Objects](/api-reference/platform-api/overview/deleting-objects).
         :::
       operationId: deleteUser
       parameters:
@@ -459,7 +459,7 @@ paths:
         This endpoint returns a list of all the accounts associated with the specified `user`.
 
         :::warning
-        This request will not return the full account number. It may return the last four digits of the account number if that information has been provided during aggregation. If you need the full account number, please refer to [List account numbers by member](https://docs.mx.com/api-reference/platform-api/reference/list-account-numbers-by-member/), [List account numbers by account](https://docs.mx.com/api-reference/platform-api/reference/list-account-numbers-by-account/), or the [Fetch Account and Routing Numbers](https://docs.mx.com/products/connectivity/instant-account-verification/fetch-account-routing-number-api/#4-read-the-account-numbers) guide.
+        This request will not return the full account number. It may return the last four digits of the account number if that information has been provided during aggregation. If you need the full account number, please refer to [List account numbers by member](/api-reference/platform-api/reference/list-account-numbers-by-member/) or [List account numbers by account](/api-reference/platform-api/reference/list-account-numbers-by-account/).
         :::
       operationId: listUserAccounts
       parameters:
@@ -593,7 +593,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/TransactionCreateResponseBody'
     get:
-      description: "Requests to this endpoint return a list of transactions associated with the specified account. <br /><br />Enhanced transaction data may be requested using the `includes` parameter. To use this optional parameter, the value should include the optional metadata requested such as `repeating_transactions`, `merchants`, `classifications`, `geolocations`. For more information, see the [Optional Enhancement Query Parameter guide](/api-reference/platform-api/reference/transactions-overview#enhanced-transactions#optional-enhancement-query-parameter)."
+      description: "Requests to this endpoint return a list of transactions associated with the specified account. <br /><br /> Enhanced transaction data may be requested using the `includes` parameter. To use this optional parameter,  the value should include the optional metadata requested such as `repeating_transactions`, `merchants`,  `classifications`, `geolocations`. For more information, see the [Optional Enhancement Query Parameter guide](/api-reference/platform-api/reference/transactions-overview#enhanced-transactions#optional-enhancement-query-parameter)."
       operationId: listTransactionsByAccount
       parameters:
         - $ref: '#/components/parameters/accountGuid'
@@ -1764,7 +1764,7 @@ paths:
         - members
   /users/{user_guid}/members/{member_guid}/transactions:
     get:
-      description: "Requests to this endpoint return a list of transactions associated with the specified `member`, across all accounts associated with that `member`. <br /><br />Enhanced transaction data may be requested using the `includes` parameter. To use this optional parameter, the value should include the optional metadata requested such as `repeating_transactions`, `merchants`, `classifications`, `geolocations`. For more information, see the [Optional Enhancement Query Parameter guide](/api-reference/platform-api/reference/transactions-overview#enhanced-transactions#optional-enhancement-query-parameter)."
+      description: "Requests to this endpoint return a list of transactions associated with the specified  `member`, across all accounts associated with that `member`. <br /><br />Enhanced transaction data  may be requested using the `includes` parameter. To use this optional parameter, the value should  include the optional metadata requested such as `repeating_transactions`, `merchants`, `classifications`,  `geolocations`. For more information, see the [Optional Enhancement Query Parameter guide](/api-reference/platform-api/reference/transactions-overview#enhanced-transactions#optional-enhancement-query-parameter)."
       operationId: listTransactionsByMember
       parameters:
         - $ref: '#/components/parameters/memberGuid'
@@ -2270,7 +2270,7 @@ paths:
         - tags
   /users/{user_guid}/tags/{tag_guid}/transactions:
     get:
-      description: "Use this endpoint to get a list of all transactions associated with a particular tag according to the tag's unique GUID. This lists all transactions that have been assigned to a particular tag using the create tagging endpoint. <br /><br />Enhanced transaction data may be requested using the `includes` parameter. To use this optional parameter, the value should include the optional metadata requested such as `repeating_transactions`, `merchants`, `classifications`, `geolocations`. For more information, see the [Optional Enhancement Query Parameter guide](/api-reference/platform-api/reference/transactions-overview#enhanced-transactions#optional-enhancement-query-parameter)."
+      description: "Use this endpoint to get a list of all transactions associated with a particular tag  according to the tag's unique GUID. This lists all transactions that have been assigned to a particular  tag using the create tagging endpoint. <br /><br />Enhanced transaction data may be requested using the  `includes` parameter. To use this optional parameter, the value should include the optional metadata  requested such as `repeating_transactions`, `merchants`, `classifications`, `geolocations`. For more  information, see the [Optional Enhancement Query Parameter guide](/api-reference/platform-api/reference/transactions-overview#enhanced-transactions#optional-enhancement-query-parameter)."
       operationId: listTransactionsByTag
       parameters:
         - $ref: '#/components/parameters/userGuid'
@@ -2393,7 +2393,7 @@ paths:
         - transaction rules
   /users/{user_guid}/transactions:
     get:
-      description: "Requests to this endpoint return a list of transactions associated with the specified `user`, across all members and accounts associated with that `user`. <br /><br />Enhanced transaction data may be requested using the `includes` parameter. To use this optional parameter, the value should include the optional metadata requested such as `repeating_transactions`, `merchants`, `classifications`, `geolocations`. For more information, see the [Optional Enhancement Query Parameter guide](/api-reference/platform-api/reference/transactions-overview#enhanced-transactions#optional-enhancement-query-parameter)."
+      description: "Requests to this endpoint return a list of transactions associated with the specified  `user`, across all members and accounts associated with that `user`. <br /><br />Enhanced transaction  data may be requested using the `includes` parameter. To use this optional parameter, the value should  include the optional metadata requested such as `repeating_transactions`, `merchants`, `classifications`,  `geolocations`. For more information, see the [Optional Enhancement Query Parameter guide](/api-reference/platform-api/reference/transactions-overview#enhanced-transactions#optional-enhancement-query-parameter)."
       operationId: listTransactions
       parameters:
         - $ref: '#/components/parameters/userGuid'
@@ -2426,7 +2426,7 @@ paths:
       - $ref: '#/components/parameters/userGuid'
       - $ref: '#/components/parameters/transactionGuid'
     get:
-      description: "Requests to this endpoint will return the attributes of the specified `transaction`. To read a manual transaction, use the manual transaction guid in the path as the `transactionGuid`. <br /><br />Enhanced transaction data may be requested using the `includes` parameter. To use this optional parameter, the value should include the optional metadata requested such as `repeating_transactions`, `merchants`, `classifications`, `geolocations`. For more information, see the [Optional Enhancement Query Parameter guide](/api-reference/platform-api/reference/transactions-overview#enhanced-transactions#optional-enhancement-query-parameter)."
+      description: "Requests to this endpoint will return the attributes of the specified `transaction`. To  read a manual transaction, use the manual transaction guid in the path as the `transactionGuid`. <br /><br /> Enhanced transaction data may be requested using the `includes` parameter. To use this optional parameter,  the value should include the optional metadata requested such as `repeating_transactions`, `merchants`,  `classifications`, `geolocations`. For more information, see the [Optional Enhancement Query Parameter guide](/api-reference/platform-api/reference/transactions-overview#enhanced-transactions#optional-enhancement-query-parameter)."
       operationId: readTransaction
       responses:
         '200':
@@ -2763,7 +2763,7 @@ paths:
                 $ref: '#/components/schemas/NotificationResponseBody'
   /users/{user_guid}/repeating_transactions:
     get:
-      description: "Retrieve a list of all recurring transactions for a user. <br /><br />For more see the [Repeating Transactions guide](repeating-transactions-overview.mdx)."
+      description: "Retrieve a list of all recurring transactions for a user. <br /><br />For more see the [Repeating Transactions guide](/api-reference/platform-api/v20111101/reference/transactions-overview#repeating-transactions)."
       operationId: repeatingTransactions
       parameters:
         - $ref: '#/components/parameters/userGuid'
@@ -2779,7 +2779,7 @@ paths:
         - transactions
   /users/{user_guid}/repeating_transactions/{repeating_transaction_guid}:
     get:
-      description: "Get a Specific Repeating Transaction. <br /><br />List For more see the [Repeating Transactions guide](repeating-transactions-overview.mdx)"
+      description: "Get a Specific Repeating Transaction. <br /><br />List For more see the  [Repeating Transactions guide](/api-reference/platform-api/v20111101/reference/transactions-overview#repeating-transactions)"
       operationId: specificRepeatingTransaction
       parameters:
         - $ref: '#/components/parameters/userGuid'
@@ -3023,7 +3023,7 @@ paths:
         - microdeposits
       operationId: readUserMicrodeposit
       summary: Read a microdeposit for a user
-      description: "Use this endpoint to read the attributes of a specific microdeposit according to its unique GUID. <br></br> Webhooks for microdeposit status changes are triggered when a status changes. The actual status of the microdeposit guid updates every minute. You may force a status update by calling the read microdeposit endpoint."
+      description: "Use this endpoint to read the attributes of a specific microdeposit according to its  unique GUID. <br></br> Webhooks for microdeposit status changes are triggered when a  status changes. The actual status of the microdeposit guid updates every minute. You may  force a status update by calling the read microdeposit endpoint."
       responses:
         '200':
           description: OK
@@ -3519,6 +3519,7 @@ components:
           nullable: true
           type: string
         instructional_text:
+          description: "Render this text when end users are asked for their credentials, as it helps end users provide the correct credentials when creating a new member. May contain `<a></a>` tags to link to explanatory material."
           example: "Some instructional text <a href=\"https://example.url.mxbank.com/instructions\" id=\"instructional_text\">for end users</a>."
           nullable: true
           type: string
@@ -6979,7 +6980,7 @@ components:
           example: false
           type: boolean
           description: |
-            Only use this option if the `widget_type` is set to `connect_widget`. This determines whether the institution search is displayed within the Connect Widget. This option must be used with `current_institution_code`, `current_instituion_guid`, or `current_member_guid`. When set to `true`, the institution search feature will be disabled and end users will not be able to navigate to it. Defaults to `false`.
+            Only use this option if the `widget_type` is set to `connect_widget`. This determines whether the institution search is displayed within the Connect Widget. This option must be used with `current_institution_code`, `current_instituion_guid`, or `current_member_guid`. When set to `true`, the institution search feature will be disabled and end users will not be able to navigate to it. Defaults to `false`. If you set `disable_institution_search` to `true`, you must also listen for the [backToSearch event](/connect/guides/handling-events/#back-to-search) to intercept the user from navigating back to search during the flow. Don't listen for any Primary Action postMessages when you disable search.  All buttons that will take a user to the search institution page are still displayed in the Connect Widget experience and your user can still select them. This may trigger during several steps in the Connect Widget flow, such as Connected, MDV/Microdeposits Verified, Login Error, and Credentials/OAuth (back button).
         enable_app2app:
           example: false
           type: boolean
@@ -8062,6 +8063,13 @@ components:
         type: array
         items:
           type: string
+    recordsPerPageMax1000:
+      description: This specifies the number of records to be returned on each page. Defaults to `25`. The valid range is from `10` to `1000`. If the value exceeds `1000`, the default value of `25` will be used instead.
+      example: 10
+      in: query
+      name: records_per_page
+      schema:
+        type: integer
     supportsAccountIdentification:
       description: Filter only institutions which support account identification.
       example: true
@@ -8098,13 +8106,6 @@ components:
       required: true
       schema:
         type: string
-    recordsPerPageMax1000:
-      description: This specifies the number of records to be returned on each page. Defaults to `25`. The valid range is from `10` to `1000`. If the value exceeds `1000`, the default value of `25` will be used instead.
-      example: 10
-      in: query
-      name: records_per_page
-      schema:
-        type: integer
     merchantLocationGuid:
       description: The unique id for a `merchant_location`.
       example: MCH-09466f0a-fb58-9d1a-bae2-2af0afbea621


### PR DESCRIPTION
# Phase 8.1: Add Commit SHA Support & Enforce Minor/Patch Only Versioning

## Changes

### 1. Add `commit_sha` to Repository Dispatch Payloads
- **File**: `.github/workflows/update.yml`
- **Changes**:
  - Updated `Update` job's repository_dispatch payload to include `commit_sha: ${{ github.sha }}`
  - Updated `Manual_Update` job's repository_dispatch payload to include `commit_sha: ${{ github.sha }}`

### 2. Remove Major Version Option from Workflows
- **Files**: `.github/workflows/update.yml`, `.github/workflows/version.yml`
- **Changes**:
  - Removed `major` from `workflow_dispatch` version_level options in `update.yml` (only `minor` and `patch` allowed)
  - Removed `major` from required PR labels check in `version.yml` (only `minor` and `patch` allowed)
  - Updated conditional logic in `update.yml` to reject `major` label

## Problem & Solution

### CDN Cache Race Condition
When the openapi repo commits a spec change and immediately triggers SDK generation, GitHub's CDN (raw.githubusercontent.com) caches files for 5 minutes. This can cause the workflow to download stale API specs instead of freshly committed changes.

**Solution**: Send `commit_sha` to SDK repos, enabling them to fetch the exact spec version that triggered the workflow, bypassing CDN cache.

### Major Version Control
Major versions must remain locked to API versions (v20111101 = 2.x, v20250224 = 3.x). This prevents accidental major version bumps.

**Solution**: Remove `major` option from all version bump workflows, only allowing `minor` and `patch`.

## Backwards Compatibility

✅ **Fully backwards compatible**
- SDK repos default to `master` branch if `commit_sha` is not provided
- Other SDK repos (C#, Go, Java, Python, Ruby) will continue working without changes
- New field in payload is simply ignored by SDKs that don't use it yet