### PR TITLE
v2025 - update member create description, add 201 response sample with error …

### DIFF
--- a/openapi/v20250224.yml
+++ b/openapi/v20250224.yml
@@ -1509,7 +1509,7 @@ paths:
       tags:
         - members
     post:
-      description: This endpoint allows you to create a new member. Members are created with the required parameters credentials and institution_code, and the optional parameters id and metadata. When creating a member, you'll need to include the correct type of credential required by the financial institution and provided by the user. You can find out which credential type is required with the `/institutions/{institution_code}/credentials` endpoint. If successful, the MX Platform API will respond with the newly-created member object. Once you successfully create a member, MX will immediately validate the provided credentials and attempt to aggregate data for accounts and transactions.
+      description: This endpoint allows you to create a new member using the required parameters `institution_code`, `credentials` (if creating a non-OAuth member), and `data_request.products`. When creating a non-OAuth member, include the correct type of credential required by the financial institution and provided by the user. You can find out which credential type is required with the `/institutions/{institution_code}/credentials` endpoint. Once you successfully create a member, MX will immediately validate the provided credentials and attempt to aggregate data. A status of 200 indicates the member was created successfully, and no aggregation was requested. A status of 201 indicates the member was created, but a product within `data_request` failed to aggregate. A status of 202 indicates the member was successfully created, and standard aggregation (no `data_request`) was requested (does not indicate success or failure).
       operationId: createMember
       parameters:
         - $ref: '#/components/parameters/acceptVersion'
@@ -1529,6 +1529,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/MemberResponseBody'
           description: OK
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MemberResponseWithJobErrorBody'
+          description: Created
         '202':
           content:
             application/json:
@@ -6770,6 +6776,29 @@ components:
           nullable: true
           type: string
       type: object
+    MemberResponseWithJobError:
+      allOf:
+        - $ref: '#/components/schemas/MemberResponse'
+        - type: object
+          properties:
+            error:
+              type: object
+              properties:
+                error_type:
+                  type: string
+                  example: "MEMBER"
+                error_code:
+                  type: integer
+                  example: 3003
+                error_message:
+                  type: string
+                  example: "There was an error attempting to process your request. The Member was created but we were unable to fulfill the data request."
+                user_message:
+                  type: string
+                  example: "We're having trouble connecting right now. Please try again later."
+                locale:
+                  type: string
+                  example: "en"
     MembersResponseBody:
       properties:
         members:
@@ -6809,6 +6838,11 @@ components:
       properties:
         member:
           $ref: '#/components/schemas/MemberResponse'
+      type: object
+    MemberResponseWithJobErrorBody:
+      properties:
+        member:
+          $ref: '#/components/schemas/MemberResponseWithJobError'
       type: object
     ManagedMemberUpdateRequest:
       properties:

--- a/openapi/v20250224.yml
+++ b/openapi/v20250224.yml
@@ -6675,6 +6675,9 @@ components:
           example: Connected to MX Bank
           nullable: true
           type: string
+        error:
+          nullable: true
+          type: object
         guid:
           description: The unique identifier for the member. Defined by MX.
           example: MBR-7c6f361b-e582-15b6-60c0-358f12466b4b


### PR DESCRIPTION
https://mxcom.atlassian.net/browse/DEVX-7543

when a member is created but the combo job fails to start, we have added a new status of 201 (created) and the member response body will now include an error object that looks like:

<img width="693" height="681" alt="Screenshot 2026-02-03 at 3 07 18 PM" src="https://github.com/user-attachments/assets/c986a0e5-b116-40dd-a703-7263150fcc3f" />


and description update to:
<img width="715" height="294" alt="Screenshot 2026-02-03 at 3 10 49 PM" src="https://github.com/user-attachments/assets/8f9347bd-bd53-4c8b-9815-00119747b772" />
